### PR TITLE
Added setup.py file for easy installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .venv/*
 .vscode/*
 *.pyc
+
+build/
+dist/
+.mypy_cache/
+rsacsc_py.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,5 @@ setup(
     install_requires=[
         'redis',
     ],
-    author="Itamar Haber",
-    license='MIT License'
+    author="Itamar Haber"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='rsacsc-py',
+    version='1.0.0',
+    packages=find_packages(),
+    url='https://github.com/itamarhaber/rsacsc-py',
+    install_requires=[
+        'redis',
+    ],
+    author="Itamar Haber",
+    license='MIT License'
+)


### PR DESCRIPTION
With this change you can install the module using pip:

pip3 install --user git+https://github.com/jblarsen/rsacsc-py

(https://github.com/itamarhaber/rsacsc-py instead if you choose to merge this)

It can also be used to publish the module to pip you so desired (you may have to add email and license information to do this, not sure).